### PR TITLE
rm from todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,3 @@ modules that are expensive (`vpc`, `config`) will work but may not be in use bec
 - [ ] Updates to work with terraform 0.12
 - [ ] Account base module should remove default vpcs
 - [ ] SNS topic that notifies a lambda that notifies me (and static site alarms go here)
-- [ ] DNS query logging to cloudwatch
-- [ ] Cloudtrail logs to cloudwatch


### PR DESCRIPTION
Turns out cloudwatch can not be written to across accounts and I don't want to create cloudwatch log groups in non-audit accounts. There are complicated firehose solutions to write logs across accounts that I also don't want to do. No need to continue this until it is needed, all logs are still in S3.