### PR TITLE
Add healthcheck options and update glacier policies

### DIFF
--- a/terraform-modules/static-site/README.md
+++ b/terraform-modules/static-site/README.md
@@ -27,6 +27,8 @@ module "site" {
     "foo.example.org" = "example.org"
   }
 
+  healthcheck_domains_enabled = true
+
   tags = var.tags
 }
 ```

--- a/terraform-modules/static-site/data.tf
+++ b/terraform-modules/static-site/data.tf
@@ -13,10 +13,10 @@ locals {
   # wildcard-hash.example.com. This will work as intended except when the is a
   # more specific wildcard-hash.example.com record, which we just assume is rare
   # enough that it's not worth worrying about.
-  healthcheck_domains = [
+  healthcheck_domains = var.healthcheck_domains_enabled ? [
     for domain in local.domain_names :
     replace(domain, "*", format("wildcard-%s", md5(domain)))
-  ]
+  ] : []
 }
 
 data "aws_route53_zone" "base" {

--- a/terraform-modules/static-site/healthcheck.tf
+++ b/terraform-modules/static-site/healthcheck.tf
@@ -1,7 +1,7 @@
 module "healthcheck" {
   source = "../route53-healthcheck//"
 
-  domains = var.healthcheck_cloudfront_enabled ? merge(local.healthcheck_domains, aws_cloudfront_distribution.cf.domain_name) : local.healthcheck_domains
+  domains = var.healthcheck_cloudfront_enabled ? merge(local.healthcheck_domains, [aws_cloudfront_distribution.cf.domain_name]) : local.healthcheck_domains
 
   sns_arn = var.healthcheck_sns_arn
 

--- a/terraform-modules/static-site/healthcheck.tf
+++ b/terraform-modules/static-site/healthcheck.tf
@@ -1,7 +1,7 @@
 module "healthcheck" {
   source = "../route53-healthcheck//"
 
-  domains = var.healthcheck_cloudfront_enabled ? merge(local.healthcheck_domains, [aws_cloudfront_distribution.cf.domain_name]) : local.healthcheck_domains
+  domains = var.healthcheck_cloudfront_enabled ? concat(local.healthcheck_domains, [aws_cloudfront_distribution.cf.domain_name]) : local.healthcheck_domains
 
   sns_arn = var.healthcheck_sns_arn
 

--- a/terraform-modules/static-site/healthcheck.tf
+++ b/terraform-modules/static-site/healthcheck.tf
@@ -1,7 +1,8 @@
 module "healthcheck" {
   source = "../route53-healthcheck//"
 
-  domains = local.healthcheck_domains
+  domains = var.healthcheck_cloudfront_enabled ? merge(local.healthcheck_domains, aws_cloudfront_distribution.cf.domain_name) : local.healthcheck_domains
+
   sns_arn = var.healthcheck_sns_arn
 
   tags = var.tags

--- a/terraform-modules/static-site/variables.tf
+++ b/terraform-modules/static-site/variables.tf
@@ -23,6 +23,18 @@ variable "bucket_logs_domain" {
   description = "The domain of the S3 bucket to write logs to"
 }
 
+variable "healthcheck_cloudfront_enabled" {
+  type        = string
+  description = "Whether or not to run a healthcheck against the default cloudfront domain"
+  default     = true
+}
+
+variable "healthcheck_domains_enabled" {
+  type        = string
+  description = "Whether or not to run a healthcheck against ALL domain names pointing to the cloudfront"
+  default     = false
+}
+
 variable "healthcheck_sns_arn" {
   type        = string
   description = "The ARN of the SNS topic to notify when the configured healthcheck is unhealthy"

--- a/terraform/aws/accounts/audit/s3_bucket_cloudtrail.tf
+++ b/terraform/aws/accounts/audit/s3_bucket_cloudtrail.tf
@@ -20,16 +20,6 @@ resource "aws_s3_bucket" "cloudtrail" {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 1
 
-    transition {
-      days          = "90"
-      storage_class = "GLACIER"
-    }
-
-    noncurrent_version_transition {
-      days          = "90"
-      storage_class = "GLACIER"
-    }
-
     expiration {
       days = "365"
     }

--- a/terraform/aws/accounts/audit/s3_bucket_logs_cloudfront.tf
+++ b/terraform/aws/accounts/audit/s3_bucket_logs_cloudfront.tf
@@ -20,22 +20,12 @@ resource "aws_s3_bucket" "logs_cloudfront" {
     enabled                                = true
     abort_incomplete_multipart_upload_days = 1
 
-    transition {
-      days          = "90"
-      storage_class = "GLACIER"
-    }
-
-    noncurrent_version_transition {
-      days          = "90"
-      storage_class = "GLACIER"
-    }
-
     expiration {
-      days = "365"
+      days = "90"
     }
 
     noncurrent_version_expiration {
-      days = "365"
+      days = "90"
     }
   }
 


### PR DESCRIPTION
Add an option to only check the cloudfront domain instead of all passed domains.

Update glacier policies for cost reasons.