### PR TITLE
Add private GitHub repos: mini, job, scratch

### DIFF
--- a/terraform/github/repo_job.tf
+++ b/terraform/github/repo_job.tf
@@ -1,0 +1,55 @@
+resource "github_repository" "job" {
+  name         = "job"
+  homepage_url = "https://seanlingren.com"
+
+  visibility = "private"
+
+  has_wiki             = false
+  has_issues           = false
+  has_projects         = false
+  has_discussions      = false
+  vulnerability_alerts = true
+
+  allow_auto_merge       = true
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+  allow_update_branch    = true
+  delete_branch_on_merge = true
+}
+
+resource "github_branch" "job" {
+  repository = github_repository.job.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "job" {
+  repository = github_repository.job.name
+  branch     = github_branch.job.branch
+}
+
+resource "github_repository_ruleset" "job" {
+  name        = "main"
+  repository  = github_repository.job.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion = true
+
+    required_linear_history = true
+    non_fast_forward        = true
+  }
+}
+
+resource "github_actions_repository_permissions" "job" {
+  repository = github_repository.job.name
+  enabled    = false
+}

--- a/terraform/github/repo_mini.tf
+++ b/terraform/github/repo_mini.tf
@@ -1,0 +1,55 @@
+resource "github_repository" "mini" {
+  name         = "mini"
+  homepage_url = "https://seanlingren.com"
+
+  visibility = "private"
+
+  has_wiki             = false
+  has_issues           = false
+  has_projects         = false
+  has_discussions      = false
+  vulnerability_alerts = true
+
+  allow_auto_merge       = true
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+  allow_update_branch    = true
+  delete_branch_on_merge = true
+}
+
+resource "github_branch" "mini" {
+  repository = github_repository.mini.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "mini" {
+  repository = github_repository.mini.name
+  branch     = github_branch.mini.branch
+}
+
+resource "github_repository_ruleset" "mini" {
+  name        = "main"
+  repository  = github_repository.mini.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion = true
+
+    required_linear_history = true
+    non_fast_forward        = true
+  }
+}
+
+resource "github_actions_repository_permissions" "mini" {
+  repository = github_repository.mini.name
+  enabled    = false
+}

--- a/terraform/github/repo_scratch.tf
+++ b/terraform/github/repo_scratch.tf
@@ -1,0 +1,55 @@
+resource "github_repository" "scratch" {
+  name         = "scratch"
+  homepage_url = "https://seanlingren.com"
+
+  visibility = "private"
+
+  has_wiki             = false
+  has_issues           = false
+  has_projects         = false
+  has_discussions      = false
+  vulnerability_alerts = true
+
+  allow_auto_merge       = true
+  allow_merge_commit     = false
+  allow_squash_merge     = true
+  allow_rebase_merge     = false
+  allow_update_branch    = true
+  delete_branch_on_merge = true
+}
+
+resource "github_branch" "scratch" {
+  repository = github_repository.scratch.name
+  branch     = "main"
+}
+
+resource "github_branch_default" "scratch" {
+  repository = github_repository.scratch.name
+  branch     = github_branch.scratch.branch
+}
+
+resource "github_repository_ruleset" "scratch" {
+  name        = "main"
+  repository  = github_repository.scratch.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion = true
+
+    required_linear_history = true
+    non_fast_forward        = true
+  }
+}
+
+resource "github_actions_repository_permissions" "scratch" {
+  repository = github_repository.scratch.name
+  enabled    = false
+}


### PR DESCRIPTION
Create three new private repositories following the existing
conventions (snippets pattern): no issues, no actions, squash
merge only, branch protection on main with linear history.

https://claude.ai/code/session_018YC8ZH6X5bSAjSJdLA93GA