### PR TITLE
Add S3 Terraform state bucket with protective policies

### DIFF
--- a/terraform/aws/accounts/prod/s3_terraform_state.tf
+++ b/terraform/aws/accounts/prod/s3_terraform_state.tf
@@ -1,5 +1,44 @@
+data "aws_iam_policy_document" "terraform_state" {
+  statement {
+    sid    = "DenyDeleteObjectVersion"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:DeleteObjectVersion",
+    ]
+
+    resources = [
+      "___ARN___/*",
+    ]
+  }
+
+  statement {
+    sid    = "DenySuspendVersioning"
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:PutBucketVersioning",
+    ]
+
+    resources = [
+      "___ARN___",
+    ]
+  }
+}
+
 module "s3_terraform_state" {
   source = "../../../../terraform-modules/s3//"
 
-  name = "lingrino-prod-usw2-terraform-state"
+  name   = "lingrino-prod-usw2-terraform-state"
+  policy = data.aws_iam_policy_document.terraform_state.json
 }

--- a/terraform/aws/accounts/prod/s3_terraform_state.tf
+++ b/terraform/aws/accounts/prod/s3_terraform_state.tf
@@ -1,0 +1,5 @@
+module "s3_terraform_state" {
+  source = "../../../../terraform-modules/s3//"
+
+  name = "lingrino-prod-usw2-terraform-state"
+}


### PR DESCRIPTION
## Summary
This PR adds a new S3 bucket configuration for storing Terraform state in the production AWS account with protective policies to prevent accidental deletion and versioning suspension.

## Key Changes
- Created new S3 Terraform state bucket module instantiation for production environment
- Implemented IAM policy document with two protective deny statements:
  - **DenyDeleteObjectVersion**: Prevents deletion of object versions to protect against accidental state loss
  - **DenySuspendVersioning**: Prevents disabling bucket versioning to maintain state history
- Bucket named `lingrino-prod-usw2-terraform-state` with policies applied to all principals

## Implementation Details
- Uses existing S3 module from `terraform-modules/s3/` for consistent infrastructure patterns
- Policy applies deny rules to all AWS principals (`"*"`) to ensure protection across all access patterns
- Versioning protection ensures state file history is preserved and recoverable
- Object version deletion protection prevents accidental removal of previous state versions

https://claude.ai/code/session_01Ce9B3u8JDtwvYZWzVZgJHR