### PR TITLE
Raise AWS billing alerts to $50 and $70

### DIFF
--- a/terraform/aws/accounts/root/budgets.tf
+++ b/terraform/aws/accounts/root/budgets.tf
@@ -2,7 +2,7 @@ resource "aws_budgets_budget" "high" {
   name = "high"
 
   budget_type  = "COST"
-  limit_amount = "15.0"
+  limit_amount = "50.0"
   limit_unit   = "USD"
 
   time_unit         = "MONTHLY"
@@ -27,7 +27,7 @@ resource "aws_budgets_budget" "very_high" {
   name = "very_high"
 
   budget_type  = "COST"
-  limit_amount = "25.0"
+  limit_amount = "70.0"
   limit_unit   = "USD"
 
   time_unit         = "MONTHLY"


### PR DESCRIPTION
## Summary

Raises the two AWS cost budgets in the root account so alerts fire at higher spend levels.

| Budget | Before | After |
|---|---|---|
| `high` | $15/mo | $50/mo |
| `very_high` | $25/mo | $70/mo |

Both budgets keep their existing forecasted `> 100%` notification to sean+aws-root@lingren.com. Only `limit_amount` changes in `terraform/aws/accounts/root/budgets.tf`.

## Apply

Plan and apply locally from `terraform/aws/accounts/root` with the `root` profile. Expect an in-place update on both `aws_budgets_budget` resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmDcv8UUu21keS63SXcsEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmDcv8UUu21keS63SXcsEF)_